### PR TITLE
corrigi erro na parte de exibir receitas

### DIFF
--- a/cozinheiros.c
+++ b/cozinheiros.c
@@ -46,6 +46,9 @@ void modulo_cozinheiro(void) {
                 break;
             case '4':
                 id_receita = ver_receitas();
+                if(id_receita == 0){
+                    break;
+                }
                 expandir_receita(id_receita);
                 break;
         }


### PR DESCRIPTION
quando o usuario digitava 0 na função 'ver_receitas' para retornar, essa escolha não estava sendo verificada e o valor entrava na função 'expandir_receita'. 